### PR TITLE
Allow POST/PATCH programatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Git Ignore this patterns:
 *.py[co]
+.python-version
 
 # Packages
 *.egg-info
@@ -70,3 +71,5 @@ cov_html
 !/src/*
 dummy_file.db
 dummy_file.db.blobs
+.vscode/
+config-local*.yaml

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -1,7 +1,9 @@
+from typing import List
 from guillotina import configure
 from guillotina import content
 from guillotina import error_reasons
 from guillotina import security
+from dataclasses import dataclass
 from guillotina._cache import FACTORY_CACHE
 from guillotina._settings import app_settings
 from guillotina.api.service import Service
@@ -137,6 +139,61 @@ class DefaultGET(Service):
         await notify(ObjectVisitedEvent(self.context))
         return result
 
+@dataclass
+class PostConfig:
+    context: IResource
+    data: dict
+    _id: str
+    user: str
+    _type: str
+
+async def post(config: PostConfig) -> IResource:
+    behaviors = config.data.get("@behaviors", None)
+
+    id_checker = get_adapter(config.context, IIDChecker)
+    if not isinstance(config._id, str) or not await id_checker(config._id, config._type):
+        raise ErrorResponse(
+            "PreconditionFailed",
+            "Invalid id: {}".format(config._id),
+            status=412,
+            reason=error_reasons.INVALID_ID,
+        )
+
+    options = {"creators": (config.user,), "contributors": (config.user,)}
+    if "uid" in config.data:
+        options["__uuid__"] = config.data.pop("uid")
+
+    # Create object
+    try:
+        obj = await create_content_in_container(config.context, config._type, config._id, **options)
+    except ValueError as e:
+        return ErrorResponse("CreatingObject", str(e), status=412)
+
+    for behavior in behaviors or ():
+        obj.add_behavior(behavior)
+
+    # Update fields
+    deserializer = query_multi_adapter((obj, None), IResourceDeserializeFromJson)
+    if deserializer is None:
+        return ErrorResponse(
+            "DeserializationError",
+            "Cannot deserialize type {}".format(obj.type_name),
+            status=412,
+            reason=error_reasons.DESERIALIZATION_FAILED,
+        )
+    await deserializer(config.data, validate_all=True, create=True)
+
+    # Local Roles assign owner as the creator user
+    get_owner = get_utility(IGetOwner)
+    roleperm = IPrincipalRoleManager(obj)
+    owner = await get_owner(obj, config.user)
+    if owner is not None:
+        roleperm.assign_role_to_principal("guillotina.Owner", owner)
+
+    config.data["id"] = obj.id
+    await notify(ObjectAddedEvent(obj, config.context, obj.id, payload=config.data))
+
+    return obj
 
 @configure.service(
     context=IResource,
@@ -159,9 +216,8 @@ class DefaultPOST(Service):
     async def __call__(self):
         """To create a content."""
         data = await self.get_data()
-        type_ = data.get("@type", None)
         id_ = data.get("id", None)
-        behaviors = data.get("@behaviors", None)
+        type_ = data.get("@type", None)
 
         if not type_:
             raise ErrorResponse(
@@ -171,72 +227,52 @@ class DefaultPOST(Service):
                 status=412,
             )
 
-        id_checker = get_adapter(self.context, IIDChecker)
         # Generate a temporary id if the id is not given
         new_id = None
         if not id_:
             generator = query_adapter(self.request, IIDGenerator)
             if generator is not None:
                 new_id = generator(data)
-                if isinstance(new_id, str) and not await id_checker(new_id, type_):
-                    raise ErrorResponse(
-                        "PreconditionFailed",
-                        "Invalid id: {}".format(new_id),
-                        status=412,
-                        reason=error_reasons.INVALID_ID,
-                    )
-        else:
-            if not isinstance(id_, str) or not await id_checker(id_, type_):
-                raise ErrorResponse(
-                    "PreconditionFailed",
-                    "Invalid id: {}".format(id_),
-                    status=412,
-                    reason=error_reasons.INVALID_ID,
-                )
+        else:  
             new_id = id_
-
+        
         user = get_authenticated_user_id()
 
-        options = {"creators": (user,), "contributors": (user,)}
-        if "uid" in data:
-            options["__uuid__"] = data.pop("uid")
-
-        # Create object
-        try:
-            obj = await create_content_in_container(self.context, type_, new_id, **options)
-        except ValueError as e:
-            return ErrorResponse("CreatingObject", str(e), status=412)
-
-        for behavior in behaviors or ():
-            obj.add_behavior(behavior)
-
-        # Update fields
-        deserializer = query_multi_adapter((obj, self.request), IResourceDeserializeFromJson)
-        if deserializer is None:
-            return ErrorResponse(
-                "DeserializationError",
-                "Cannot deserialize type {}".format(obj.type_name),
-                status=412,
-                reason=error_reasons.DESERIALIZATION_FAILED,
-            )
-
-        await deserializer(data, validate_all=True, create=True)
-
-        # Local Roles assign owner as the creator user
-        get_owner = get_utility(IGetOwner)
-        roleperm = IPrincipalRoleManager(obj)
-        owner = await get_owner(obj, user)
-        if owner is not None:
-            roleperm.assign_role_to_principal("guillotina.Owner", owner)
-
-        data["id"] = obj.id
-        await notify(ObjectAddedEvent(obj, self.context, obj.id, payload=data))
+        config = PostConfig(context=self.context, data=data, _id=new_id, user=user, _type=type_)
+        obj = await post(config=config)
 
         headers = {"Access-Control-Expose-Headers": "Location", "Location": get_object_url(obj, self.request)}
-
         serializer = query_multi_adapter((obj, self.request), IResourceSerializeToJsonSummary)
         response = await serializer()
         return Response(content=response, status=201, headers=headers)
+
+
+@dataclass
+class PatchConfig:
+    context: IResource
+    data: dict
+
+async def patch(config: PatchConfig) -> IResource:
+    behaviors = config.data.get("@behaviors", None)
+    for behavior in behaviors or ():
+        try:
+            config.context.add_behavior(behavior)
+        except (TypeError, ComponentLookupError):
+            return HTTPPreconditionFailed(
+                content={"message": f"{behavior} is not a valid behavior", "behavior": behavior}
+            )
+    await notify(BeforeObjectModifiedEvent(config.context, payload=config.data))
+    deserializer = query_multi_adapter((config.context, None), IResourceDeserializeFromJson)
+    if deserializer is None:
+        raise ErrorResponse(
+                "DeserializationError",
+                "Cannot deserialize type {}".format(config.context.type_name),
+                status=412,
+                reason=error_reasons.DESERIALIZATION_FAILED,
+            )
+    await deserializer(config.data)
+    await notify(ObjectModifiedEvent(config.context, payload=config.data))
+    return config.context
 
 
 @configure.service(
@@ -255,31 +291,10 @@ class DefaultPOST(Service):
 class DefaultPATCH(Service):
     async def __call__(self):
         data = await self.get_data()
-
-        behaviors = data.get("@behaviors", None)
-        for behavior in behaviors or ():
-            try:
-                self.context.add_behavior(behavior)
-            except (TypeError, ComponentLookupError):
-                return HTTPPreconditionFailed(
-                    content={"message": f"{behavior} is not a valid behavior", "behavior": behavior}
-                )
-
-        deserializer = query_multi_adapter((self.context, self.request), IResourceDeserializeFromJson)
-        if deserializer is None:
-            raise ErrorResponse(
-                "DeserializationError",
-                "Cannot deserialize type {}".format(self.context.type_name),
-                status=412,
-                reason=error_reasons.DESERIALIZATION_FAILED,
-            )
-
-        await notify(BeforeObjectModifiedEvent(self.context, payload=data))
-
-        await deserializer(data)
-
-        await notify(ObjectModifiedEvent(self.context, payload=data))
-
+    
+        config = PatchConfig(context=self.context, data=data)
+        context = await patch(config)
+    
         return Response(status=204)
 
 

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -158,7 +158,7 @@ async def post(context: IResource, data: dict, _id: str, user: str, type_: str) 
     try:
         obj = await create_content_in_container(context, type_, _id, **options)
     except ValueError as e:
-        return ErrorResponse("CreatingObject", str(e), status=412)
+        raise ErrorResponse("CreatingObject", str(e), status=412)
 
     for behavior in behaviors or ():
         obj.add_behavior(behavior)
@@ -166,7 +166,7 @@ async def post(context: IResource, data: dict, _id: str, user: str, type_: str) 
     # Update fields
     deserializer = query_multi_adapter((obj, None), IResourceDeserializeFromJson)
     if deserializer is None:
-        return ErrorResponse(
+        raise ErrorResponse(
             "DeserializationError",
             "Cannot deserialize type {}".format(obj.type_name),
             status=412,
@@ -185,6 +185,7 @@ async def post(context: IResource, data: dict, _id: str, user: str, type_: str) 
     await notify(ObjectAddedEvent(obj, context, obj.id, payload=data))
 
     return obj
+
 
 @configure.service(
     context=IResource,
@@ -243,7 +244,7 @@ async def patch(context: IResource, data: dict) -> IResource:
         try:
             context.add_behavior(behavior)
         except (TypeError, ComponentLookupError):
-            return HTTPPreconditionFailed(
+            raise HTTPPreconditionFailed(
                 content={"message": f"{behavior} is not a valid behavior", "behavior": behavior}
             )
     await notify(BeforeObjectModifiedEvent(context, payload=data))

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -224,9 +224,9 @@ class DefaultPOST(Service):
             generator = query_adapter(self.request, IIDGenerator)
             if generator is not None:
                 new_id = generator(data)
-        else:  
+        else:
             new_id = id_
-        
+
         user = get_authenticated_user_id()
 
         obj = await post(context=self.context, data=data, _id=new_id, user=user, type_=type_)
@@ -250,11 +250,11 @@ async def patch(context: IResource, data: dict) -> IResource:
     deserializer = query_multi_adapter((context, None), IResourceDeserializeFromJson)
     if deserializer is None:
         raise ErrorResponse(
-                "DeserializationError",
-                "Cannot deserialize type {}".format(context.type_name),
-                status=412,
-                reason=error_reasons.DESERIALIZATION_FAILED,
-            )
+            "DeserializationError",
+            "Cannot deserialize type {}".format(context.type_name),
+            status=412,
+            reason=error_reasons.DESERIALIZATION_FAILED,
+        )
     await deserializer(data)
     await notify(ObjectModifiedEvent(context, payload=data))
     return context
@@ -276,7 +276,7 @@ async def patch(context: IResource, data: dict) -> IResource:
 class DefaultPATCH(Service):
     async def __call__(self):
         data = await self.get_data()
-        context = await patch(context=self.context, data=data)
+        _ = await patch(context=self.context, data=data)
         return Response(status=204)
 
 

--- a/guillotina/api/content.py
+++ b/guillotina/api/content.py
@@ -144,10 +144,7 @@ async def post(context: IResource, data: dict, _id: str, user: str, type_: str) 
     id_checker = get_adapter(context, IIDChecker)
     if not isinstance(_id, str) or not await id_checker(_id, type_):
         raise ErrorResponse(
-            "PreconditionFailed",
-            "Invalid id: {}".format(_id),
-            status=412,
-            reason=error_reasons.INVALID_ID,
+            "PreconditionFailed", "Invalid id: {}".format(_id), status=412, reason=error_reasons.INVALID_ID,
         )
 
     options = {"creators": (user,), "contributors": (user,)}

--- a/guillotina/content.py
+++ b/guillotina/content.py
@@ -651,13 +651,15 @@ async def get_all_behaviors(content, create=False, load=True, preload_only=False
             data_keys[inst.__annotations_data_key__] = inst
     if data_keys:
         txn = get_transaction()
+        if txn is None:
+            raise Exception("No transaction available")
         annotation_data = await txn.get_annotations(content, list(data_keys))
         for inst in instances:
             key = getattr(inst, "__annotations_data_key__", None)
             if key and key in annotation_data:
                 content.__gannotations__[key] = annotation_data[key]
     if preload_only:
-        return
+        return []
 
     # Load all (for all non-preload items, this takes care of initialization).
     behaviors = []

--- a/guillotina/db/interfaces.py
+++ b/guillotina/db/interfaces.py
@@ -233,8 +233,7 @@ class IStorage(Interface):
         """
         load the current tid for an object from oid
         """
-
-    async def store(oid, old_serial, writer, obj, txn):
+    async def store(oid, old_serial, writer, serialized, obj, txn):
         """
         store oid with obj
         """

--- a/guillotina/db/interfaces.py
+++ b/guillotina/db/interfaces.py
@@ -233,6 +233,7 @@ class IStorage(Interface):
         """
         load the current tid for an object from oid
         """
+
     async def store(oid, old_serial, writer, serialized, obj, txn):
         """
         store oid with obj

--- a/guillotina/db/interfaces.py
+++ b/guillotina/db/interfaces.py
@@ -37,6 +37,11 @@ class ITransaction(Interface):
         Add hook to be called after transaction commit
         """
 
+    async def get_annotations(base_obj, ids, reader=None):
+        """
+        Get annotations for object
+        """
+
     async def add_after_commit_failure_hook(hook, *real_args, args=None, kws=None, **kwargs):
         """
         Add hook to be called after a failure to perform transaction commit

--- a/guillotina/db/storages/base.py
+++ b/guillotina/db/storages/base.py
@@ -49,7 +49,7 @@ class BaseStorage:
     async def get_one_row(self, smt, *args):
         raise NotImplemented()  # pragma: no cover
 
-    async def start_transaction(self, txn, retries=0):
+    async def start_transaction(self, txn):
         raise NotImplemented()  # pragma: no cover
 
     async def get_conflicts(self, txn):
@@ -86,6 +86,12 @@ class BaseStorage:
         raise NotImplemented()  # pragma: no cover
 
     async def get_annotation_keys(self, txn, oid):
+        raise NotImplemented()  # pragma: no cover
+
+    async def terminate(self, conn):
+        raise NotImplemented()  # pragma: no cover
+
+    async def remove(self):
         raise NotImplemented()  # pragma: no cover
 
     async def write_blob_chunk(self, txn, bid, oid, chunk_index, data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 Cython==0.29.6
-aiohttp>=3.0.0,<3.6.0;python_version<"3.8"
-aiohttp>=3.6.0,<4.0.0;python_version>="3.8"
-asyncpg==0.20.0
-cffi==1.12.2
+aiohttp==3.7.4
+asyncpg==0.21.0
+cffi==1.15.1
 chardet==3.0.4
 jsonschema==2.6.0
 multidict==4.5.2
@@ -15,7 +14,7 @@ six==1.11.0
 ujson==1.35
 yarl==1.2.6
 zope.interface==5.1.0
-argon2-cffi==18.3.0
+argon2-cffi==19.2.0
 backoff==1.10.0
 prometheus-client==0.8.0
 brotli==1.0.9


### PR DESCRIPTION
Refactor to extract post and patch methods non-request logic so they can be used programmatically.